### PR TITLE
Fix chat response substring handling

### DIFF
--- a/aliClient/src/main/java/ir/dotin/service/ChatClientApi.java
+++ b/aliClient/src/main/java/ir/dotin/service/ChatClientApi.java
@@ -23,8 +23,13 @@ public class ChatClientApi {
                 .body(ollamaRequest)
                 .retrieve()
                 .body(OllamaResponse.class);
-        String finalResponse = response.response.substring(response.response.lastIndexOf("</think>") + 8, response.response.length());
-         return finalResponse;
+
+        String body = response.response;
+        int marker = body.lastIndexOf("</think>");
+        if (marker >= 0) {
+            return body.substring(marker + 8);
+        }
+        return body;
     }
 
 


### PR DESCRIPTION
## Summary
- sanitize ChatClientApi output when `</think>` is missing

## Testing
- `mvn -q test` *(fails: could not resolve dependencies, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687b1f15496c83298cebc8212619fc6c