### PR TITLE
refactor: externalize API keys and add Bitbucket service

### DIFF
--- a/aliClient/src/main/java/ir/dotin/config/ApiKeyConfig.java
+++ b/aliClient/src/main/java/ir/dotin/config/ApiKeyConfig.java
@@ -1,0 +1,23 @@
+package ir.dotin.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApiKeyConfig {
+
+    @Value("${deepseek.api.key}")
+    private String deepSeekApiKey;
+
+    @Value("${bitbucket.api.key}")
+    private String bitbucketApiKey;
+
+    public String getDeepSeekApiKey() {
+        return deepSeekApiKey;
+    }
+
+    public String getBitbucketApiKey() {
+        return bitbucketApiKey;
+    }
+}
+

--- a/aliClient/src/main/java/ir/dotin/service/BitbucketService.java
+++ b/aliClient/src/main/java/ir/dotin/service/BitbucketService.java
@@ -1,0 +1,52 @@
+package ir.dotin.service;
+
+import ir.dotin.config.ApiKeyConfig;
+import ir.dotin.model.bitbucket.DiffModel;
+import org.json.JSONObject;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class BitbucketService {
+
+    private final RestClient restClient;
+    private final String apiKey;
+
+    public BitbucketService(RestClient.Builder restClientBuilder, ApiKeyConfig apiKeyConfig) {
+        this.restClient = restClientBuilder.baseUrl("http://localhost:7990/rest/api/1.0").build();
+        this.apiKey = apiKeyConfig.getBitbucketApiKey();
+    }
+
+    public DiffModel getPullRequestDiff(String projectKey, String repoSlug, int prId) {
+        String url = String.format("/projects/%s/repos/%s/pull-requests/%d/diff", projectKey, repoSlug, prId);
+        return restClient.get()
+                .uri(url)
+                .header("Authorization", "Bearer " + apiKey)
+                .retrieve()
+                .toEntity(DiffModel.class)
+                .getBody();
+    }
+
+    public String postPullRequestComment(String projectKey, String repoSlug, int prId, String comment) {
+        String url = String.format("/projects/%s/repos/%s/pull-requests/%d/comments", projectKey, repoSlug, prId);
+        JSONObject payload = new JSONObject();
+        payload.put("text", comment);
+        return restClient.post()
+                .uri(url)
+                .header("Authorization", "Bearer " + apiKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload.toString())
+                .retrieve()
+                .body(String.class);
+    }
+
+    public String approvePullRequest(String projectKey, String repoSlug, int prId) {
+        String url = String.format("/projects/%s/repos/%s/pull-requests/%d/approve", projectKey, repoSlug, prId);
+        return restClient.post()
+                .uri(url)
+                .header("Authorization", "Bearer " + apiKey)
+                .retrieve()
+                .body(String.class);
+    }
+}

--- a/aliClient/src/main/java/ir/dotin/service/DeepSeekAiClientService.java
+++ b/aliClient/src/main/java/ir/dotin/service/DeepSeekAiClientService.java
@@ -1,16 +1,14 @@
 package ir.dotin.service;
 
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import ir.dotin.config.ApiKeyConfig;
 import ir.dotin.model.bitbucket.DiffModel;
 import ir.dotin.model.domain.DeepSeekMessageRequest;
 import ir.dotin.model.domain.DeepSeekRequest;
 import ir.dotin.model.domain.DeepSeekResponse;
-
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -18,52 +16,59 @@ import org.springframework.web.client.RestClient;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Slf4j
 public class DeepSeekAiClientService {
 
-    private RestClient restClient;
+    private final RestClient restClient;
+    private final BitbucketService bitbucketService;
+    private final String deepSeekApiKey;
 
     String promptTemplate = """
-            ROLE: Senior Software Engineer (Java 8, Hibernate Expert)  
-            
-            TASK: Review the given Java source code for improper Hibernate session management.  
-            
-            TARGET PATTERN:  
-            Look for any occurrence where a Hibernate session is opened using:  
+            ROLE: Senior Software Engineer (Java 8, Hibernate Expert)
+
+            TASK: Review the given Java source code for improper Hibernate session management.
+
+            TARGET PATTERN:
+            Look for any occurrence where a Hibernate session is opened using:
             HibernateSession session = HibernateManager.createSession();
-            
-            but the corresponding code block does not contain a session.close() call.  
-            
-            RESPONSE RULES:  
-            - Output ONLY the raw code block(s) that match this condition.  
-            - Do NOT add explanations, analysis, or extra text.  
-            - If no matching code exists, output : file has no session that are not Closed.  
-            
-            INPUT_CODE:  
+
+            but the corresponding code block does not contain a session.close() call.
+
+            RESPONSE RULES:
+            - Output ONLY the raw code block(s) that match this condition.
+            - Do NOT add explanations, analysis, or extra text.
+            - If no matching code exists, output : file has no session that are not Closed.
+
+            INPUT_CODE:
             \"\"\"%s\"\"\"
             """;
 
+    public DeepSeekAiClientService(RestClient.Builder restClientBuilder,
+                                   BitbucketService bitbucketService,
+                                   ApiKeyConfig apiKeyConfig) {
+        this.restClient = restClientBuilder.baseUrl("https://api.deepseek.com").build();
+        this.bitbucketService = bitbucketService;
+        this.deepSeekApiKey = apiKeyConfig.getDeepSeekApiKey();
+    }
 
     public String getDeepSeekApiClientMessage(String deepSeekApiClientMessage) {
         List<DeepSeekMessageRequest> deepSeekMessageRequests = new ArrayList<>();
         deepSeekMessageRequests.add(new DeepSeekMessageRequest("system", "You are a helpful assistant."));
         deepSeekMessageRequests.add(new DeepSeekMessageRequest("user", deepSeekApiClientMessage));
         DeepSeekRequest deepSeekRequest = new DeepSeekRequest("deepseek-chat", deepSeekMessageRequests, false);
-        restClient = RestClient.builder().baseUrl("https://api.deepseek.com").build();
         DeepSeekResponse response = restClient.post()
                 .uri("/chat/completions")
                 .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + "sk-6c97f1e767804952a92d5f2344c9e22f")
+                .header("Authorization", "Bearer " + deepSeekApiKey)
                 .body(deepSeekRequest)
                 .retrieve()
                 .body(DeepSeekResponse.class);
         return response.getChoices().get(0).getMessage().getContent();
     }
-
 
     public String getDeepSeekApiChatBitbucketMessage(String deepSeekApiChatBitbucketMessage) {
         JSONObject root = new JSONObject(deepSeekApiChatBitbucketMessage);
@@ -73,76 +78,39 @@ public class DeepSeekAiClientService {
         JSONObject repository = fromRef.getJSONObject("repository");
         String repoSlug = repository.getString("slug");
         String projectKey = repository.getJSONObject("project").getString("key");
-        String apiUrl = String.format(
-                "http://localhost:7990/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/diff",
-                projectKey, repoSlug, prId
-        );
-        String deepValue = "";
-        restClient = RestClient.builder().baseUrl(apiUrl).build();
-        DiffModel diffModel = restClient.get()
-                .header("Authorization", "Bearer ".concat("BBDC-MjcwMjc1NjgyNzI1Ouz/VnT2LW9PxIElA+jmw5j6yGZX"))
-                .retrieve()
-                .toEntity(DiffModel.class)
-                .getBody();
-        ObjectMapper objectMapper = new ObjectMapper();
         try {
+            DiffModel diffModel = bitbucketService.getPullRequestDiff(projectKey, repoSlug, prId);
+            ObjectMapper objectMapper = new ObjectMapper();
             String diffValue = objectMapper.writeValueAsString(diffModel);
-            deepValue = getDeepSeekApiClientMessage(diffValue);
-            String commentApiUrl = String.format(
-                    "http://localhost:7990/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments",
-                    projectKey, repoSlug, prId
-            );
-            JSONObject commentPayLoad = new JSONObject();
-            commentPayLoad.put("text", deepValue);
-            restClient = RestClient.builder().baseUrl(commentApiUrl).build();
-            String response = restClient.post()
-                    .header("Authorization", "Bearer ".concat("BBDC-MjcwMjc1NjgyNzI1Ouz/VnT2LW9PxIElA+jmw5j6yGZX"))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(commentPayLoad.toString())
-                    .retrieve()
-                    .body(String.class);
-            String approveApiUrl = String.format(
-                    "http://localhost:7990/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/approve",
-                    projectKey, repoSlug, prId
-            );
-            restClient = RestClient.builder().baseUrl(approveApiUrl).build();
-            String approveResponse = restClient.post()
-                    .header("Authorization", "Bearer ".concat("BBDC-MjcwMjc1NjgyNzI1Ouz/VnT2LW9PxIElA+jmw5j6yGZX"))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(commentPayLoad.toString())
-                    .retrieve()
-                    .body(String.class);
-            return response;
+            String deepValue = getDeepSeekApiClientMessage(diffValue);
+            String commentResponse = bitbucketService.postPullRequestComment(projectKey, repoSlug, prId, deepValue);
+            bitbucketService.approvePullRequest(projectKey, repoSlug, prId);
+            return commentResponse;
         } catch (JsonProcessingException e) {
-            log.error(e.getMessage());
-        }
-        return deepValue;
-    }
-
-
-
-    public String getOpenSessionSecarioFromfile(){
-        try {
-            String javaFilePath = "/home/ftamir79/IdeaProjects/spring-ai-version/aliClient/src/main/java/ir/dotin/tempo/Test.java";
-            String javaFileCode = Files.readString(Paths.get(javaFilePath));
-            List<DeepSeekMessageRequest> deepSeekMessageRequests = new ArrayList<>();
-            String finalPromt= String.format(promptTemplate,javaFileCode);
-            deepSeekMessageRequests.add(new DeepSeekMessageRequest("system", finalPromt));
-            DeepSeekRequest deepSeekRequest = new DeepSeekRequest("deepseek-chat", deepSeekMessageRequests, false);
-            restClient = RestClient.builder().baseUrl("https://api.deepseek.com").build();
-            DeepSeekResponse response = restClient.post()
-                    .uri("/chat/completions")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("Authorization", "Bearer " + "sk-6c97f1e767804952a92d5f2344c9e22f")
-                    .body(deepSeekRequest)
-                    .retrieve()
-                    .body(DeepSeekResponse.class);
-            return response.getChoices().get(0).getMessage().getContent();
-        }catch (IOException e){
             log.error(e.getMessage());
         }
         return null;
     }
 
-
+    public String getOpenSessionSecarioFromfile() {
+        try {
+            String javaFilePath = "/home/ftamir79/IdeaProjects/spring-ai-version/aliClient/src/main/java/ir/dotin/tempo/Test.java";
+            String javaFileCode = Files.readString(Paths.get(javaFilePath));
+            List<DeepSeekMessageRequest> deepSeekMessageRequests = new ArrayList<>();
+            String finalPromt = String.format(promptTemplate, javaFileCode);
+            deepSeekMessageRequests.add(new DeepSeekMessageRequest("system", finalPromt));
+            DeepSeekRequest deepSeekRequest = new DeepSeekRequest("deepseek-chat", deepSeekMessageRequests, false);
+            DeepSeekResponse response = restClient.post()
+                    .uri("/chat/completions")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + deepSeekApiKey)
+                    .body(deepSeekRequest)
+                    .retrieve()
+                    .body(DeepSeekResponse.class);
+            return response.getChoices().get(0).getMessage().getContent();
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+        return null;
+    }
 }

--- a/aliClient/src/main/resources/application.yaml
+++ b/aliClient/src/main/resources/application.yaml
@@ -6,3 +6,9 @@ spring:
       base-url: http://localhost:11434
       chat:
         model: deepseek-r1:8b
+deepseek:
+  api:
+    key: ${DEEPSEEK_API_KEY:}
+bitbucket:
+  api:
+    key: ${BITBUCKET_API_KEY:}


### PR DESCRIPTION
## Summary
- add configuration to externalize DeepSeek and Bitbucket API keys
- create dedicated BitbucketService for pull request operations
- refactor DeepSeek service to use BitbucketService and config keys

## Testing
- `mvn -q -pl aliClient test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68985255cc40832989642fb9ce17ed7e